### PR TITLE
Courriel d'alertes

### DIFF
--- a/YellowDuck.Api/BackgroundJobs/SendAlert.cs
+++ b/YellowDuck.Api/BackgroundJobs/SendAlert.cs
@@ -1,0 +1,110 @@
+﻿using Hangfire;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using YellowDuck.Api.DbModel;
+using YellowDuck.Api.DbModel.Enums;
+using YellowDuck.Api.EmailTemplates.Models;
+using YellowDuck.Api.Extensions;
+using YellowDuck.Api.Helpers;
+using YellowDuck.Api.Services.Mailer;
+
+namespace YellowDuck.Api.BackgroundJobs
+{
+    public class SendAlert
+    {
+        private readonly AppDbContext db;
+        private readonly IMailer mailer;
+        private readonly ILogger<SendAlert> logger;
+
+        public SendAlert(AppDbContext db, IMailer mailer, ILogger<SendAlert> logger)
+        {
+            this.db = db;
+            this.mailer = mailer;
+            this.logger = logger;
+        }
+
+        public static void RegisterJob(IConfiguration config)
+        {
+            RecurringJob.AddOrUpdate<SendAlert>(
+                x => x.Run(),
+                Cron.Daily(),
+                TimeZoneInfo.FindSystemTimeZoneById(config["systemLocalTimezone"]));
+        }
+
+        public async Task Run()
+        {
+            var lastWeekUTC = DateTime.UtcNow.AddDays(-7);
+            var alerts = await db.Alerts
+                .Include(x => x.User)
+                .Include(x => x.Address)
+                .Where(x => x.LastSendDateUTC == null || x.LastSendDateUTC < lastWeekUTC.Date)
+                .Where(x => x.EmailConfirmed || x.UserId != null)
+                .ToArrayAsync();
+            var recentAds = await db.Ads
+                .Include(x => x.Address)
+                .Where(x => x.CreatedAtUTC >= lastWeekUTC.Date)
+                .ToArrayAsync();
+            await db.SaveChangesAsync();
+
+            foreach (var alert in alerts)
+            {
+                var filteredAds = recentAds
+                    .Where(x => x.Category == alert.Category)
+                    .Where(x => alert.DayAvailability == false || x.DayAvailability.Any())
+                    .Where(x => alert.EveningAvailability == false || x.EveningAvailability.Any())
+                    .Where(x => CoordinateHelper.GetDistance(x.Address.Latitude, x.Address.Longitude, alert.Address.Latitude, alert.Address.Longitude) <= alert.Radius);
+
+                switch (alert.Category)
+                {
+                    case AdCategory.ProfessionalKitchen:
+                        filteredAds = filteredAds.Where(x => !alert.ProfessionalKitchenEquipments.Any() || x.ProfessionalKitchenEquipments.Select(x => x.ProfessionalKitchenEquipment).Intersect(alert.ProfessionalKitchenEquipments.Select(x => x.ProfessionalKitchenEquipment)).Count() == alert.ProfessionalKitchenEquipments.Count);
+                        break;
+                    case AdCategory.DeliveryTruck:
+                        filteredAds = filteredAds.Where(x => alert.DeliveryTruckType == null || x.DeliveryTruckType == alert.DeliveryTruckType)
+                                               .Where(x => !alert.Refrigerated || alert.Refrigerated)
+                                               .Where(x => !alert.CanHaveDriver || alert.CanHaveDriver)
+                                               .Where(x => !alert.CanSharedRoad || alert.CanSharedRoad);
+                        break;
+                }
+
+                if (filteredAds.Any())
+                {
+                    var filtersParams = new UrlHelper.AdsFilteredParams {
+                        Category = alert.Category,
+                        DeliveryTruckType = alert.DeliveryTruckType,
+                        ProfessionalKitchenEquipment = alert.ProfessionalKitchenEquipments?.Select(x => x.ProfessionalKitchenEquipment).ToList(),
+                        Refrigerated = alert.Refrigerated,
+                        CanHaveDriver = alert.CanHaveDriver,
+                        CanSharedRoad = alert.CanSharedRoad,
+                        DayAvailability = alert.DayAvailability,
+                        EveningAvailability = alert.EveningAvailability,
+                        Address = alert.Address.FormatedAddress,
+                        Latitude = alert.Address.Latitude,
+                        Longitude = alert.Address.Longitude,
+                        View = UrlHelper.AdsFilteredParams.ViewMode.LIST,
+                        Sort = UrlHelper.AdsFilteredParams.SortType.DATE,
+                        Direction = UrlHelper.AdsFilteredParams.DirectionValue.DESC
+                    };
+
+                    
+                    var emailModel = new AlertEmail(alert.User?.Email ?? alert.Email)
+                    {
+                        Category = AdCategoryHelper.AdCategoryToFrenchString(alert.Category),
+                        AdsCount = filteredAds.Count(),
+                        CtaUrl = filteredAds.Count() == 1 ? UrlHelper.Ad(filteredAds.First().GetIdentifier()) : UrlHelper.AdsFiltered(filtersParams),
+                        UnsubscribeUrl = UrlHelper.UnsubscribeAlert(alert.GetIdentifier()),
+                        ManageAlertUrl = (alert.User != null) ? UrlHelper.ManageAlert() : null
+                    };
+                    await mailer.Send(emailModel);
+
+                    alert.LastSendDateUTC = DateTime.UtcNow;
+                    await db.SaveChangesAsync();
+                }
+            }
+        }
+    }
+}

--- a/YellowDuck.Api/BackgroundJobs/SendAlert.cs
+++ b/YellowDuck.Api/BackgroundJobs/SendAlert.cs
@@ -56,12 +56,12 @@ namespace YellowDuck.Api.BackgroundJobs
                     .Where(x => x.Category == alert.Category)
                     .Where(x => alert.DayAvailability == false || x.DayAvailability.Any())
                     .Where(x => alert.EveningAvailability == false || x.EveningAvailability.Any())
-                    .Where(x => CoordinateHelper.GetDistance(x.Address.Latitude, x.Address.Longitude, alert.Address.Latitude, alert.Address.Longitude) <= alert.Radius);
+                    .Where(x => CoordinateHelper.GetDistanceInMeters(x.Address.Latitude, x.Address.Longitude, alert.Address.Latitude, alert.Address.Longitude)/1000 <= alert.Radius);
 
                 switch (alert.Category)
                 {
                     case AdCategory.ProfessionalKitchen:
-                        filteredAds = filteredAds.Where(x => !alert.ProfessionalKitchenEquipments.Any() || x.ProfessionalKitchenEquipments.Select(x => x.ProfessionalKitchenEquipment).Intersect(alert.ProfessionalKitchenEquipments.Select(x => x.ProfessionalKitchenEquipment)).Count() == alert.ProfessionalKitchenEquipments.Count);
+                        filteredAds = filteredAds.Where(x => !alert.ProfessionalKitchenEquipments?.Any() ?? true || x.ProfessionalKitchenEquipments.Select(x => x.ProfessionalKitchenEquipment).Intersect(alert.ProfessionalKitchenEquipments.Select(x => x.ProfessionalKitchenEquipment)).Count() == alert.ProfessionalKitchenEquipments.Count);
                         break;
                     case AdCategory.DeliveryTruck:
                         filteredAds = filteredAds.Where(x => alert.DeliveryTruckType == null || x.DeliveryTruckType == alert.DeliveryTruckType)
@@ -100,11 +100,11 @@ namespace YellowDuck.Api.BackgroundJobs
                         ManageAlertUrl = (alert.User != null) ? UrlHelper.ManageAlert() : null
                     };
                     await mailer.Send(emailModel);
-
+                    logger.LogInformation($"Alert id {alert.Id} sent with {filteredAds.Count()} ad(s)");
                     alert.LastSendDateUTC = DateTime.UtcNow;
                     await db.SaveChangesAsync();
                 }
-            }
+            } 
         }
     }
 }

--- a/YellowDuck.Api/DbModel/Entities/Alerts/Alert.cs
+++ b/YellowDuck.Api/DbModel/Entities/Alerts/Alert.cs
@@ -11,7 +11,7 @@ namespace YellowDuck.Api.DbModel.Entities.Alerts
         public AppUser User { get; set; }
         public AdCategory Category { get; set; }
         public IList<AlertProfessionalKitchenEquipment> ProfessionalKitchenEquipments { get; set; }
-        public DeliveryTruckType DeliveryTruckType { get; set; }
+        public DeliveryTruckType? DeliveryTruckType { get; set; }
         public bool Refrigerated { get; set; }
         public bool CanSharedRoad { get; set; }
         public bool CanHaveDriver { get; set; }
@@ -22,6 +22,6 @@ namespace YellowDuck.Api.DbModel.Entities.Alerts
         public AlertAddress Address { get; set; }
         public string Email { get; set; }
         public bool EmailConfirmed { get; set; }
-        public DateTime LastSendDate { get; set; }
+        public DateTime? LastSendDateUTC { get; set; }
     }
 }

--- a/YellowDuck.Api/DbModel/Entities/Alerts/AlertAddress.cs
+++ b/YellowDuck.Api/DbModel/Entities/Alerts/AlertAddress.cs
@@ -1,4 +1,7 @@
-﻿namespace YellowDuck.Api.DbModel.Entities.Alerts
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace YellowDuck.Api.DbModel.Entities.Alerts
 {
     public class AlertAddress : IHaveLongIdentifier
     {
@@ -16,5 +19,24 @@
         public string Sublocality { get; set; }
 
         public string Raw { get; set; }
+
+        public string FormatedAddress
+        {
+            get {
+                if (this == null) return "";
+                var firstSection = new List<string>();
+                var lastSection = new List<string>();
+                if (!string.IsNullOrEmpty(StreetNumber)) firstSection.Add(StreetNumber);
+                if (!string.IsNullOrEmpty(Route)) firstSection.Add(Route);
+                if(!string.IsNullOrEmpty(Locality)) lastSection.Add(Locality);
+
+                var address = string.Join(" ", firstSection);
+                if (address.Trim() != "" && lastSection.Any()) address += ", ";
+                address += string.Join(", ", lastSection);
+                if (string.IsNullOrEmpty(address)) address = $"{Latitude}, {Longitude}";
+
+                return address.Trim();
+            }
+        }
     }
 }

--- a/YellowDuck.Api/EmailTemplates/Alert.cshtml
+++ b/YellowDuck.Api/EmailTemplates/Alert.cshtml
@@ -1,0 +1,35 @@
+﻿@using YellowDuck.Api.Helpers
+@using YellowDuck.Api.Constants
+@model YellowDuck.Api.EmailTemplates.Models.AlertEmail
+@{
+    Layout = "_EmailLayout.cshtml";
+}
+
+@if (Model.AdsCount > 1)
+{
+    <p>
+        @Model.AdsCount offres @Model.Category qui pourraient vous intéresser viennent d'être publiées.
+    </p>
+    <p>
+        <a href="@Model.BaseUrl/@Model.CtaUrl">Aller voir les offres</a>
+    </p>
+}
+else
+{
+    <p>
+        Une offre @Model.Category qui pourrait vous intéresser vient d'être publiée.
+    </p>
+    <p>
+        <a href="@Model.BaseUrl/@Model.CtaUrl)">Aller voir l'offre</a>
+    </p>
+}
+
+
+   <p>
+     <a href="@Model.BaseUrl/@Model.UnsubscribeUrl)">Se désabonner de cette alerte</a>
+    @if(Model.ManageAlertUrl != null)
+    {
+        <text>•</text> <a href="@Model.BaseUrl/@Model.ManageAlertUrl)">Gérer ses alertes</a>
+    }
+</p> 
+

--- a/YellowDuck.Api/EmailTemplates/Alert.cshtml
+++ b/YellowDuck.Api/EmailTemplates/Alert.cshtml
@@ -20,16 +20,16 @@ else
         Une offre @Model.Category qui pourrait vous intéresser vient d'être publiée.
     </p>
     <p>
-        <a href="@Model.BaseUrl/@Model.CtaUrl)">Aller voir l'offre</a>
+        <a href="@Model.BaseUrl/@Model.CtaUrl">Aller voir l'offre</a>
     </p>
 }
 
 
    <p>
-     <a href="@Model.BaseUrl/@Model.UnsubscribeUrl)">Se désabonner de cette alerte</a>
+     <a href="@Model.BaseUrl/@Model.UnsubscribeUrl">Se désabonner de cette alerte</a>
     @if(Model.ManageAlertUrl != null)
     {
-        <text>•</text> <a href="@Model.BaseUrl/@Model.ManageAlertUrl)">Gérer ses alertes</a>
+        <text>•</text> <a href="@Model.BaseUrl/@Model.ManageAlertUrl">Gérer ses alertes</a>
     }
 </p> 
 

--- a/YellowDuck.Api/EmailTemplates/Alert.cshtml
+++ b/YellowDuck.Api/EmailTemplates/Alert.cshtml
@@ -4,32 +4,65 @@
 @{
     Layout = "_EmailLayout.cshtml";
 }
-
+<p style="font-style:italic;">--- English will follow ---</p>
+<br>
 @if (Model.AdsCount > 1)
 {
     <p>
-        @Model.AdsCount offres @Model.Category qui pourraient vous intéresser viennent d'être publiées.
+        @Model.AdsCount offres @AdCategoryHelper.AdCategoryToFrenchString(Model.Category) qui pourraient vous intéresser viennent d'être publiées.
     </p>
     <p>
-        <a href="@Model.BaseUrl/@Model.CtaUrl">Aller voir les offres</a>
+        <a href="@Model.BaseUrl/@Model.CtaUrlFr">Aller voir les offres</a>
     </p>
 }
 else
 {
     <p>
-        Une offre @Model.Category qui pourrait vous intéresser vient d'être publiée.
+        Une offre @AdCategoryHelper.AdCategoryToFrenchString(Model.Category) qui pourrait vous intéresser vient d'être publiée.
     </p>
     <p>
-        <a href="@Model.BaseUrl/@Model.CtaUrl">Aller voir l'offre</a>
+        <a href="@Model.BaseUrl/@Model.CtaUrlFr">Aller voir l'offre</a>
     </p>
 }
 
 
-   <p>
-     <a href="@Model.BaseUrl/@Model.UnsubscribeUrl">Se désabonner de cette alerte</a>
-    @if(Model.ManageAlertUrl != null)
+<p>
+    <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeAlert(Model.AlertIdentifier, Model.To, Locales.FR)">Se désabonner de cette alerte</a>
+    @if (Model.CanManageAlert)
     {
-        <text>•</text> <a href="@Model.BaseUrl/@Model.ManageAlertUrl">Gérer ses alertes</a>
+        <text>•</text> <a href="@Model.BaseUrl/@UrlHelper.ManageAlert(Locales.FR)">Gérer ses alertes</a>
     }
-</p> 
+</p>
 
+<br>
+<br>
+<p style="font-style:italic;">--- English version ---</p>
+<br>
+
+@if (Model.AdsCount > 1)
+{
+    <p>
+        @Model.AdsCount offers @AdCategoryHelper.AdCategoryToEnglishString(Model.Category) that might interest you have just been published.
+    </p>
+    <p>
+        <a href="@Model.BaseUrl/@Model.CtaUrlEn">Go see the offers</a>
+    </p>
+}
+else
+{
+    <p>
+        One offer @AdCategoryHelper.AdCategoryToEnglishString(Model.Category) that might interest you has just been published.
+    </p>
+    <p>
+        <a href="@Model.BaseUrl/@Model.CtaUrlEn">Go see the offer</a>
+    </p>
+}
+
+
+<p>
+    <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeAlert(Model.AlertIdentifier, Model.To, Locales.EN)">Unsubscribe from this alert</a>
+    @if (Model.CanManageAlert)
+    {
+        <text>•</text> <a href="@Model.BaseUrl/@UrlHelper.ManageAlert(Locales.EN)">Manage your alerts</a>
+    }
+</p>

--- a/YellowDuck.Api/EmailTemplates/ConfirmAlert.cshtml
+++ b/YellowDuck.Api/EmailTemplates/ConfirmAlert.cshtml
@@ -5,7 +5,8 @@
 @{
     Layout = "_EmailLayout.cshtml";
 }
-
+<p style="font-style:italic;">--- English will follow ---</p>
+<br>
 <p>Bonjour,</p>
 <p>Veuillez confirmer la création d'une alerte courriel @AdCategoryHelper.AdCategoryToFrenchString(Model.Alert.Category).</p>
 <p>
@@ -14,3 +15,16 @@
     </a>
 </p>
 <p>Merci</p>
+
+<br>
+<br>
+<p style="font-style:italic;">--- English version ---</p>
+<br>
+<p>Hello,</p>
+<p>Please confirm the creation of an email alert @AdCategoryHelper.AdCategoryToEnglishString(Model.Alert.Category).</p>
+<p>
+    <a href="@Model.BaseUrl/@UrlHelper.ConfirmAlert(Model.Alert.GetIdentifier().ToString(), Model.Alert.Email, Locales.EN)">
+        This is the link you need to click to confirm your alert.
+    </a>
+</p>
+<p>Thanks</p>

--- a/YellowDuck.Api/EmailTemplates/ConfirmAlert.cshtml
+++ b/YellowDuck.Api/EmailTemplates/ConfirmAlert.cshtml
@@ -1,0 +1,16 @@
+﻿@using YellowDuck.Api.Helpers
+@using YellowDuck.Api.Constants
+@using YellowDuck.Api.Extensions;
+@model YellowDuck.Api.EmailTemplates.Models.ConfirmAlertEmail
+@{
+    Layout = "_EmailLayout.cshtml";
+}
+
+<p>Bonjour,</p>
+<p>Veuillez confirmer la création d'une alerte courriel @AdCategoryHelper.AdCategoryToFrenchString(Model.Alert.Category).</p>
+<p>
+    <a href="@Model.BaseUrl/@UrlHelper.ConfirmAlert(Model.Alert.GetIdentifier().ToString(), Model.Alert.Email, Locales.FR)">
+        Ceci est le lien sur lequel vous devez cliquer pour confirmer votre alerte.
+    </a>
+</p>
+<p>Merci</p>

--- a/YellowDuck.Api/EmailTemplates/Models/AlertEmail.cs
+++ b/YellowDuck.Api/EmailTemplates/Models/AlertEmail.cs
@@ -1,0 +1,16 @@
+﻿using YellowDuck.Api.Services.Mailer;
+
+namespace YellowDuck.Api.EmailTemplates.Models
+{
+    public class AlertEmail : EmailModel
+    {
+        public override string Subject => $"Alerte Mutuali: {AdsCount} offre(s) pourrai(en)t vous intéresser.";
+        public string Category { get; set; }
+        public int AdsCount { get; set; }
+        public string CtaUrl { get; set; }
+        public string UnsubscribeUrl { get; set; }
+        public string ManageAlertUrl { get; set; }
+
+        public AlertEmail(string to) : base(to) { }
+    }
+}

--- a/YellowDuck.Api/EmailTemplates/Models/AlertEmail.cs
+++ b/YellowDuck.Api/EmailTemplates/Models/AlertEmail.cs
@@ -1,15 +1,18 @@
-﻿using YellowDuck.Api.Services.Mailer;
+﻿using GraphQL.Conventions;
+using YellowDuck.Api.DbModel.Enums;
+using YellowDuck.Api.Services.Mailer;
 
 namespace YellowDuck.Api.EmailTemplates.Models
 {
     public class AlertEmail : EmailModel
     {
         public override string Subject => $"Alerte Mutuali: {AdsCount} offre(s) pourrai(en)t vous intéresser.";
-        public string Category { get; set; }
+        public Id AlertIdentifier { get; set; }
+        public AdCategory Category { get; set; }
         public int AdsCount { get; set; }
-        public string CtaUrl { get; set; }
-        public string UnsubscribeUrl { get; set; }
-        public string ManageAlertUrl { get; set; }
+        public bool CanManageAlert { get; set; }
+        public string CtaUrlFr { get; set; }
+        public string CtaUrlEn { get; set; }
 
         public AlertEmail(string to) : base(to) { }
     }

--- a/YellowDuck.Api/EmailTemplates/Models/ConfirmAlertEmail.cs
+++ b/YellowDuck.Api/EmailTemplates/Models/ConfirmAlertEmail.cs
@@ -1,0 +1,17 @@
+﻿using YellowDuck.Api.DbModel.Entities.Alerts;
+using YellowDuck.Api.Services.Mailer;
+
+namespace YellowDuck.Api.EmailTemplates.Models
+{
+    public class ConfirmAlertEmail : EmailModel
+    {
+        public override string Subject => "Confirmer l'alerte Mutuali";
+
+        public Alert Alert { get; set; }
+
+        public ConfirmAlertEmail(string to, Alert alert) : base(to)
+        {
+            Alert = alert;
+        }
+    }
+}

--- a/YellowDuck.Api/Gql/Schema/GraphTypes/AlertGraphType.cs
+++ b/YellowDuck.Api/Gql/Schema/GraphTypes/AlertGraphType.cs
@@ -44,7 +44,7 @@ namespace YellowDuck.Api.Gql.Schema.GraphTypes
             var professionalKitchenEquipments = await ctx.LoadProfessionalKitchenEquipmentsByAlertId(id);
             return professionalKitchenEquipments.Select(x => x.ProfessionalKitchenEquipment).ToList();
         }
-        public Task<DeliveryTruckType> DeliveryTruckType => WithData(x => x.DeliveryTruckType);
+        public Task<DeliveryTruckType?> DeliveryTruckType => WithData(x => x.DeliveryTruckType);
 
         public Task<bool> Refrigerated => WithData(x => x.Refrigerated);
 

--- a/YellowDuck.Api/Gql/Schema/Mutation.cs
+++ b/YellowDuck.Api/Gql/Schema/Mutation.cs
@@ -160,7 +160,6 @@ namespace YellowDuck.Api.Gql.Schema
             return mediator.Send(input.Value);
         }
 
-        [ApplyPolicy(AuthorizationPolicies.ManageAlert)]
         [AnnotateErrorCodes(typeof(DeleteAlert))]
         public Task<DeleteAlert.Payload> DeleteAlert(
             [Inject] IMediator mediator,

--- a/YellowDuck.Api/Gql/Schema/Mutation.cs
+++ b/YellowDuck.Api/Gql/Schema/Mutation.cs
@@ -151,6 +151,14 @@ namespace YellowDuck.Api.Gql.Schema
             return mediator.Send(input.Value);
         }
 
+        [AnnotateErrorCodes(typeof(ConfirmAlert))]
+        public Task<ConfirmAlert.Payload> ConfirmAlert(
+            [Inject] IMediator mediator,
+            NonNull<ConfirmAlert.Input> input)
+        {
+            return mediator.Send(input.Value);
+        }
+
         [ApplyPolicy(AuthorizationPolicies.ManageAlert)]
         [AnnotateErrorCodes(typeof(UpdateAlert))]
         public Task<UpdateAlert.Payload> UpdateAlert(

--- a/YellowDuck.Api/Helpers/AdCategoryHelper.cs
+++ b/YellowDuck.Api/Helpers/AdCategoryHelper.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using YellowDuck.Api.DbModel.Enums;
+
+namespace YellowDuck.Api.Helpers
+{
+    public static class AdCategoryHelper
+    {
+        public static string AdCategoryToFrenchString(AdCategory adCategory)
+        {
+            var dict = new Dictionary<AdCategory, string>() {
+                { AdCategory.ProfessionalKitchen, "Cuisines professionnelles" },
+                { AdCategory.DeliveryTruck, "Camions de livraison" },
+                { AdCategory.StorageSpace, "Espaces d'entreposage" },
+                { AdCategory.Other, "Autres" },
+            };
+            return dict[adCategory];
+        }
+    }
+}
+

--- a/YellowDuck.Api/Helpers/AdCategoryHelper.cs
+++ b/YellowDuck.Api/Helpers/AdCategoryHelper.cs
@@ -16,6 +16,17 @@ namespace YellowDuck.Api.Helpers
             };
             return dict[adCategory];
         }
+
+        public static string AdCategoryToEnglishString(AdCategory adCategory)
+        {
+            var dict = new Dictionary<AdCategory, string>() {
+                { AdCategory.ProfessionalKitchen, "Professional kitchens" },
+                { AdCategory.DeliveryTruck, "Delivery trucks" },
+                { AdCategory.StorageSpace, "Storage spaces" },
+                { AdCategory.Other, "Others" },
+            };
+            return dict[adCategory];
+        }
     }
 }
 

--- a/YellowDuck.Api/Helpers/CoordinateHelper.cs
+++ b/YellowDuck.Api/Helpers/CoordinateHelper.cs
@@ -6,6 +6,7 @@ namespace YellowDuck.Api.Helpers
     {
         public static double GetDistanceInMeters(double longitude, double latitude, double otherLongitude, double otherLatitude)
         {
+            // Source: https://stackoverflow.com/a/51839058
             var d1 = latitude * (Math.PI / 180.0);
             var num1 = longitude * (Math.PI / 180.0);
             var d2 = otherLatitude * (Math.PI / 180.0);

--- a/YellowDuck.Api/Helpers/CoordinateHelper.cs
+++ b/YellowDuck.Api/Helpers/CoordinateHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace YellowDuck.Api.Helpers
+{
+    public static class CoordinateHelper
+    {
+        public static double GetDistance(double longitude, double latitude, double otherLongitude, double otherLatitude)
+        {
+            var d1 = latitude * (Math.PI / 180.0);
+            var num1 = longitude * (Math.PI / 180.0);
+            var d2 = otherLatitude * (Math.PI / 180.0);
+            var num2 = otherLongitude * (Math.PI / 180.0) - num1;
+            var d3 = Math.Pow(Math.Sin((d2 - d1) / 2.0), 2.0) + Math.Cos(d1) * Math.Cos(d2) * Math.Pow(Math.Sin(num2 / 2.0), 2.0);
+
+            return 6376500.0 * (2.0 * Math.Atan2(Math.Sqrt(d3), Math.Sqrt(1.0 - d3)));
+        }
+    }
+}

--- a/YellowDuck.Api/Helpers/CoordinateHelper.cs
+++ b/YellowDuck.Api/Helpers/CoordinateHelper.cs
@@ -4,7 +4,7 @@ namespace YellowDuck.Api.Helpers
 {
     public static class CoordinateHelper
     {
-        public static double GetDistance(double longitude, double latitude, double otherLongitude, double otherLatitude)
+        public static double GetDistanceInMeters(double longitude, double latitude, double otherLongitude, double otherLatitude)
         {
             var d1 = latitude * (Math.PI / 180.0);
             var num1 = longitude * (Math.PI / 180.0);

--- a/YellowDuck.Api/Helpers/UrlHelper.cs
+++ b/YellowDuck.Api/Helpers/UrlHelper.cs
@@ -31,6 +31,12 @@ namespace YellowDuck.Api.Helpers
             return $"alertes{langParameter}";
         }
 
+        public static string ConfirmAlert(string id, string email, string lang = null)
+        {
+            var langParameter = (lang != null) ? $"&lang={lang}" : "";
+            return $"alertes/confirmer/{id}?email={email}{langParameter}";
+        }
+
         public static string UnsubscribeAlert(Id id, string lang = null)
         {
             var langParameter = (lang != null) ? $"?lang={lang}" : "";

--- a/YellowDuck.Api/Helpers/UrlHelper.cs
+++ b/YellowDuck.Api/Helpers/UrlHelper.cs
@@ -1,4 +1,10 @@
-﻿namespace YellowDuck.Api.Helpers
+﻿using GraphQL.Conventions;
+using Newtonsoft.Json.Serialization;
+using System.Collections.Generic;
+using System.Linq;
+using YellowDuck.Api.DbModel.Enums;
+
+namespace YellowDuck.Api.Helpers
 {
     public static class UrlHelper
     {
@@ -17,6 +23,89 @@
         {
             var langParameter = (lang != null) ? $"&lang={lang}" : "";
             return $"reinitialiser-mot-de-passe?email={System.Net.WebUtility.UrlEncode(to)}&token={System.Net.WebUtility.UrlEncode(token)}{langParameter}";
+        }
+
+        public static string ManageAlert(string lang = null)
+        {
+            var langParameter = (lang != null) ? $"?lang={lang}" : "";
+            return $"alertes{langParameter}";
+        }
+
+        public static string UnsubscribeAlert(Id id, string lang = null)
+        {
+            var langParameter = (lang != null) ? $"?lang={lang}" : "";
+            return $"alertes/supprimer/{id}{langParameter}";
+        }
+
+        public static string Ad(Id id, string lang = null)
+        {
+            var langParameter = (lang != null) ? $"?lang={lang}" : "";
+            return $"annonces/{id}{langParameter}";
+        }
+
+        public static string AdsFiltered(AdsFilteredParams filters, string lang = null)
+        {
+            var snakeCaseStrategy = new SnakeCaseNamingStrategy();
+            var langParameter = (lang != null) ? $"&lang={lang}" : "";
+            var queryParameters = new List<string>
+            {
+                $"address={System.Net.WebUtility.UrlEncode(filters.Address)}",
+                $"lat={System.Net.WebUtility.UrlEncode(filters.Latitude.ToString())}",
+                $"lon={System.Net.WebUtility.UrlEncode(filters.Longitude.ToString())}",
+                $"category={snakeCaseStrategy.GetPropertyName(filters.Category.ToString(), false).ToUpper()}"
+            };
+            if (filters.DeliveryTruckType != null) queryParameters.Add($"deliveryTruckType={snakeCaseStrategy.GetPropertyName(filters.DeliveryTruckType.ToString(), false).ToUpper()}");
+            if (filters.DayAvailability) queryParameters.Add("dayAvailability=ANY");
+            if (filters.EveningAvailability) queryParameters.Add("eveningAvailability=ANY");
+            if (filters.Refrigerated) queryParameters.Add("refrigerated=true");
+            if (filters.CanHaveDriver) queryParameters.Add("canHaveDriver=true");
+            if (filters.CanSharedRoad) queryParameters.Add("canSharedRoad=true");
+            if (filters.View != null) queryParameters.Add($"view={filters.View}");
+            if(filters.ProfessionalKitchenEquipment?.Any() ?? false)
+            {
+                foreach(var professionalKitchenEquipment in filters.ProfessionalKitchenEquipment)
+                {
+                    queryParameters.Add($"professionalKitchenEquipment={snakeCaseStrategy.GetPropertyName(professionalKitchenEquipment.ToString(), false).ToUpper()}");
+                }
+            }
+
+            return $"annonces?{string.Join("&", queryParameters)}{langParameter}";
+        }
+
+        public class AdsFilteredParams
+        {
+            public AdCategory? Category { get; set; }
+            public DeliveryTruckType? DeliveryTruckType { get; set; }
+            public IList<ProfessionalKitchenEquipment> ProfessionalKitchenEquipment { get; set; }
+            public bool DayAvailability { get; set; }
+            public bool EveningAvailability { get; set; }
+            public bool Refrigerated { get; set; }
+            public bool CanHaveDriver { get; set; }
+            public bool CanSharedRoad { get; set; }
+            public string Address { get; set; }
+            public double Latitude { get; set; }
+            public double Longitude { get; set; }
+            public ViewMode? View { get; set; }
+            public SortType? Sort { get; set; }
+            public DirectionValue? Direction { get; set; }
+
+            public enum ViewMode
+            {
+                LIST,
+                MAP
+            }
+
+            public enum SortType
+            {
+                DATE,
+                DISTANCE
+            }
+
+            public enum DirectionValue
+            {
+                ASC,
+                DESC
+            }
         }
     }
 }

--- a/YellowDuck.Api/Helpers/UrlHelper.cs
+++ b/YellowDuck.Api/Helpers/UrlHelper.cs
@@ -37,10 +37,10 @@ namespace YellowDuck.Api.Helpers
             return $"alertes/confirmer/{id}?email={email}{langParameter}";
         }
 
-        public static string UnsubscribeAlert(Id id, string lang = null)
+        public static string UnsubscribeAlert(Id id, string email, string lang = null)
         {
-            var langParameter = (lang != null) ? $"?lang={lang}" : "";
-            return $"alertes/supprimer/{id}{langParameter}";
+            var langParameter = (lang != null) ? $"&lang={lang}" : "";
+            return $"alertes/supprimer/{id}?email={email}{langParameter}";
         }
 
         public static string Ad(Id id, string lang = null)

--- a/YellowDuck.Api/Migrations/20230306135726_AddAlertsBasedEntities.Designer.cs
+++ b/YellowDuck.Api/Migrations/20230306135726_AddAlertsBasedEntities.Designer.cs
@@ -10,7 +10,7 @@ using YellowDuck.Api.DbModel;
 namespace YellowDuck.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20230224202701_AddAlertsBasedEntities")]
+    [Migration("20230306135726_AddAlertsBasedEntities")]
     partial class AddAlertsBasedEntities
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -421,7 +421,7 @@ namespace YellowDuck.Api.Migrations
                     b.Property<bool>("DayAvailability")
                         .HasColumnType("bit");
 
-                    b.Property<int>("DeliveryTruckType")
+                    b.Property<int?>("DeliveryTruckType")
                         .HasColumnType("int");
 
                     b.Property<string>("Email")
@@ -433,7 +433,7 @@ namespace YellowDuck.Api.Migrations
                     b.Property<bool>("EveningAvailability")
                         .HasColumnType("bit");
 
-                    b.Property<DateTime>("LastSendDate")
+                    b.Property<DateTime?>("LastSendDateUTC")
                         .HasColumnType("datetime2");
 
                     b.Property<double?>("Radius")

--- a/YellowDuck.Api/Migrations/20230306135726_AddAlertsBasedEntities.cs
+++ b/YellowDuck.Api/Migrations/20230306135726_AddAlertsBasedEntities.cs
@@ -36,7 +36,7 @@ namespace YellowDuck.Api.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     UserId = table.Column<string>(type: "nvarchar(450)", nullable: true),
                     Category = table.Column<int>(type: "int", nullable: false),
-                    DeliveryTruckType = table.Column<int>(type: "int", nullable: false),
+                    DeliveryTruckType = table.Column<int>(type: "int", nullable: true),
                     Refrigerated = table.Column<bool>(type: "bit", nullable: false),
                     CanSharedRoad = table.Column<bool>(type: "bit", nullable: false),
                     CanHaveDriver = table.Column<bool>(type: "bit", nullable: false),
@@ -46,7 +46,7 @@ namespace YellowDuck.Api.Migrations
                     AddressId = table.Column<long>(type: "bigint", nullable: false),
                     Email = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     EmailConfirmed = table.Column<bool>(type: "bit", nullable: false),
-                    LastSendDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    LastSendDateUTC = table.Column<DateTime>(type: "datetime2", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/YellowDuck.Api/Migrations/AppDbContextModelSnapshot.cs
+++ b/YellowDuck.Api/Migrations/AppDbContextModelSnapshot.cs
@@ -419,7 +419,7 @@ namespace YellowDuck.Api.Migrations
                     b.Property<bool>("DayAvailability")
                         .HasColumnType("bit");
 
-                    b.Property<int>("DeliveryTruckType")
+                    b.Property<int?>("DeliveryTruckType")
                         .HasColumnType("int");
 
                     b.Property<string>("Email")
@@ -431,7 +431,7 @@ namespace YellowDuck.Api.Migrations
                     b.Property<bool>("EveningAvailability")
                         .HasColumnType("bit");
 
-                    b.Property<DateTime>("LastSendDate")
+                    b.Property<DateTime?>("LastSendDateUTC")
                         .HasColumnType("datetime2");
 
                     b.Property<double?>("Radius")

--- a/YellowDuck.Api/Requests/Commands/Mutations/Accounts/CreateUserAccount.cs
+++ b/YellowDuck.Api/Requests/Commands/Mutations/Accounts/CreateUserAccount.cs
@@ -17,20 +17,24 @@ using GraphQL.Conventions;
 using YellowDuck.Api.Gql.Schema.Types;
 using System.Collections.Generic;
 using System.Linq;
+using YellowDuck.Api.DbModel;
+using Microsoft.EntityFrameworkCore;
 
 namespace YellowDuck.Api.Requests.Commands.Mutations.Accounts
 {
     public class CreateUserAccount : IRequestHandler<CreateUserAccount.Input, CreateUserAccount.Payload>
     {
         private readonly UserManager<AppUser> userManager;
+        private readonly AppDbContext db;
         private readonly IMailer mailer;
         private readonly ILogger<CreateUserAccount> logger;
         private readonly IHttpContextAccessor httpContextAccessor;
 
-        public CreateUserAccount(UserManager<AppUser> userManager, IMailer mailer, ILogger<CreateUserAccount> logger, IHttpContextAccessor httpContextAccessor)
+        public CreateUserAccount(UserManager<AppUser> userManager, AppDbContext db, IMailer mailer, ILogger<CreateUserAccount> logger, IHttpContextAccessor httpContextAccessor)
         {
             this.httpContextAccessor = httpContextAccessor;
             this.userManager = userManager;
+            this.db = db;
             this.mailer = mailer;
             this.logger = logger;
         }
@@ -74,6 +78,10 @@ namespace YellowDuck.Api.Requests.Commands.Mutations.Accounts
             var result = await userManager.CreateAsync(user, request.Password);
             result.AssertSuccess();
             var confirmToken = await userManager.GenerateEmailConfirmationTokenAsync(user);
+
+            var alerts = await db.Alerts.Where(x => x.Email == request.Email && x.EmailConfirmed).ToListAsync(cancellationToken: cancellationToken);
+            alerts.ForEach(x => x.UserId = user.Id);
+            await db.SaveChangesAsync(cancellationToken);
 
             await mailer.Send(new ConfirmEmailEmail(request.Email, confirmToken, request.ReturnPath));
 

--- a/YellowDuck.Api/Requests/Commands/Mutations/Alerts/ConfirmAlert.cs
+++ b/YellowDuck.Api/Requests/Commands/Mutations/Alerts/ConfirmAlert.cs
@@ -1,0 +1,62 @@
+﻿using YellowDuck.Api.Extensions;
+using YellowDuck.Api.Plugins.GraphQL;
+using YellowDuck.Api.Plugins.MediatR;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+using YellowDuck.Api.DbModel;
+using System.Linq;
+using GraphQL.Conventions;
+using YellowDuck.Api.DbModel.Entities.Alerts;
+using Microsoft.EntityFrameworkCore;
+using YellowDuck.Api.Gql.Schema.GraphTypes;
+
+namespace YellowDuck.Api.Requests.Commands.Mutations.Alerts
+{
+    public class ConfirmAlert : IRequestHandler<ConfirmAlert.Input, ConfirmAlert.Payload>
+    {
+        private readonly AppDbContext db;
+        private readonly ILogger<ConfirmAlert> logger;
+
+        public ConfirmAlert(AppDbContext db, ILogger<ConfirmAlert> logger)
+        {
+            this.db = db;
+            this.logger = logger;
+        }
+
+        public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
+        {
+            var alertId = request.AlertId.LongIdentifierForType<Alert>();
+            var alert = await db.Alerts.Where(x => x.Id == alertId && x.Email == request.Email).FirstOrDefaultAsync(cancellationToken: cancellationToken);
+            if (alert == null || alert.EmailConfirmed) throw new NoNeedToConfirmException();
+
+            alert.EmailConfirmed = true;
+            await db.SaveChangesAsync(cancellationToken);
+
+            logger.LogInformation($"Alert Id {alert.Id} email address confirmed {alert.Email}");
+
+            return new Payload
+            {
+                Alert = new AlertGraphType(alert)
+            };
+        }
+
+        [MutationInput]
+        public class Input : IRequest<Payload>
+        {
+            public Id AlertId { get; set; }
+            public string Email { get; set; }
+
+        }
+
+        [MutationPayload]
+        public class Payload
+        {
+            public AlertGraphType Alert { get; set; }
+        }
+
+        public abstract class ConfirmEmailException : RequestValidationException { }
+        public class NoNeedToConfirmException : ConfirmEmailException { }
+    }
+}

--- a/YellowDuck.Api/Requests/Commands/Mutations/Alerts/DeleteAlert.cs
+++ b/YellowDuck.Api/Requests/Commands/Mutations/Alerts/DeleteAlert.cs
@@ -29,7 +29,7 @@ namespace YellowDuck.Api.Requests.Commands.Mutations.Alerts
             if (request.Email == null) throw new EmailNotSetException();
             var alertId = request.AlertId.LongIdentifierForType<Alert>();
 
-            var alert = await db.Alerts.Include(x => x.User).Where(x => (x.User != null && x.User.Email == request.Email) || x.Email == request.Email).FirstOrDefaultAsync(cancellationToken);
+            var alert = await db.Alerts.Include(x => x.User).Where(x => x.Id == alertId).Where(x => (x.User != null && x.User.Email == request.Email) || x.Email == request.Email).FirstOrDefaultAsync(cancellationToken);
 
             if (alert == null) throw new AlertNotFoundException();
 

--- a/YellowDuck.Api/Startup.cs
+++ b/YellowDuck.Api/Startup.cs
@@ -243,6 +243,7 @@ namespace YellowDuck.Api
             CloseCompletedContract.RegisterJob(Configuration);
             SendPayoutsForContractsStarted.RegisterJob(Configuration);
             SendKPIsEmail.RegisterJob(Configuration);
+            SendAlert.RegisterJob(Configuration);
         }
 
         private void ConfigureDbContext(DbContextOptionsBuilder options)

--- a/YellowDuck.ApiTests/Requests/Commands/Mutations/Accounts/CreateUserAccountTests.cs
+++ b/YellowDuck.ApiTests/Requests/Commands/Mutations/Accounts/CreateUserAccountTests.cs
@@ -32,7 +32,7 @@ namespace YellowDuck.ApiTests.Requests.Commands.Mutations.Accounts
         public CreateUserAccountTest()
         {
             mailer = new Mock<IMailer>();
-            handler = new CreateUserAccount(UserManager, mailer.Object, NullLogger<CreateUserAccount>.Instance, HttpContextAccessor);
+            handler = new CreateUserAccount(UserManager, DbContext, mailer.Object, NullLogger<CreateUserAccount>.Instance, HttpContextAccessor);
         }
 
         [Fact]

--- a/YellowDuck.ApiTests/Requests/Commands/Mutations/Alerts/DeleteAlertTest.cs
+++ b/YellowDuck.ApiTests/Requests/Commands/Mutations/Alerts/DeleteAlertTest.cs
@@ -38,6 +38,7 @@ namespace YellowDuck.ApiTests.Requests.Commands.Mutations.Alerts
                     Route = "Rue Bickell",
                     StreetNumber = "395"
                 }.NonNull(),
+                User = user,
                 Radius = 10
             };
 
@@ -49,7 +50,8 @@ namespace YellowDuck.ApiTests.Requests.Commands.Mutations.Alerts
         {
             return new DeleteAlert.Input
             {
-                AlertId = alert.GetIdentifier()
+                AlertId = alert.GetIdentifier(),
+                Email = "test@example.com"
             };
         }
 
@@ -70,11 +72,24 @@ namespace YellowDuck.ApiTests.Requests.Commands.Mutations.Alerts
         {
             var input = new DeleteAlert.Input
             {
-                AlertId = "QWxlcnQ6MjAwMDc="
+                AlertId = "QWxlcnQ6MjAwMDc=",
+                Email = "test@example.com"
             };
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<DeleteAlert.AlertNotFoundException>();
+        }
+
+        [Fact]
+        public async Task ShouldThrowErrorOnUnSpecifiedEmail()
+        {
+            var input = new DeleteAlert.Input
+            {
+                AlertId = "QWxlcnQ6MjAwMDc=",
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<DeleteAlert.EmailNotSetException>();
         }
     }
 }

--- a/YellowDuck.FE/src/components/alert/form.vue
+++ b/YellowDuck.FE/src/components/alert/form.vue
@@ -126,7 +126,7 @@
               :label="$t('label.your-email')"
               :placeholder="$t('placeholder.email')"
               name="email"
-              rules="email"
+              rules="required|email"
               required
             />
           </fieldset>

--- a/YellowDuck.FE/src/components/alert/snippet.vue
+++ b/YellowDuck.FE/src/components/alert/snippet.vue
@@ -48,6 +48,9 @@ export default {
     alert: {
       type: Object,
       required: true
+    },
+    email: {
+      type: String
     }
   },
   computed: {
@@ -73,7 +76,7 @@ export default {
   },
   methods: {
     async deleteAlert() {
-      await deleteAlert(this.alert.id);
+      await deleteAlert(this.alert.id, this.email);
       NotificationService.showSuccess(this.$t("notification.alert-deleted"));
       this.$emit("deleted");
     }

--- a/YellowDuck.FE/src/components/pages/alert/add.vue
+++ b/YellowDuck.FE/src/components/pages/alert/add.vue
@@ -25,7 +25,7 @@ import NavClose from "@/components/nav/close";
 import FormComplete from "@/components/generic/form-complete";
 import AlertForm from "@/components/alert/form";
 
-import { URL_ROOT, URL_AD_ALERT_LIST } from "@/consts/urls";
+import { URL_LIST_AD, URL_AD_ALERT_LIST } from "@/consts/urls";
 
 import { createAlert } from "@/services/alert";
 
@@ -44,20 +44,19 @@ export default {
     }
   },
   data() {
+    var ctas = [];
+    if (this.isConnected) {
+      ctas = [
+        { action: () => this.$router.push({ name: URL_AD_ALERT_LIST }), text: this.$t("btn.manage-my-alerts") },
+        { action: () => this.$router.push({ name: URL_LIST_AD }), text: this.$t("btn.return-map") }
+      ];
+    } else {
+      ctas = [{ action: () => this.$router.push({ name: URL_LIST_AD }), text: this.$t("btn.return-map") }];
+    }
     return {
       alertCreated: false,
       isSubmitted: false,
-      formCompleteCtas: [
-        { action: () => this.$router.push({ name: URL_AD_ALERT_LIST }), text: this.$t("btn.manage-my-alerts") },
-        { action: () => this.$router.push({ name: URL_ROOT }), text: this.$t("btn.return-dashboard") }
-      ]
-    };
-  },
-  gqlErrors() {
-    return {
-      IMAGE_NOT_FOUND(error) {
-        return this.$t("error.image-upload");
-      }
+      formCompleteCtas: ctas
     };
   },
   methods: {

--- a/YellowDuck.FE/src/components/pages/alert/confirm.vue
+++ b/YellowDuck.FE/src/components/pages/alert/confirm.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="alert-list w-100 mt-4 mt-md-5">
+    <div class="no-content my-5 py-sm-4">
+      <img class="no-content__img mb-4" alt="" :src="require('@/assets/ambiance/flying-star.svg')" />
+      <p>{{ $t("notification.alert-confirmed") }}</p>
+      <b-button variant="primary" :to="{ name: $consts.urls.URL_LIST_AD }">{{ $t("btn.return-map") }} </b-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { confirmAlert } from "@/services/alert";
+export default {
+  async mounted() {
+    await confirmAlert(this.$route.params.id, this.$route.query.email);
+  }
+};
+</script>

--- a/YellowDuck.FE/src/components/pages/alert/delete.vue
+++ b/YellowDuck.FE/src/components/pages/alert/delete.vue
@@ -3,7 +3,7 @@
     <div class="no-content my-5 py-sm-4">
       <img class="no-content__img mb-4" alt="" :src="require('@/assets/ambiance/nothing.svg')" />
       <p>{{ $t("notification.alert-deleted") }}</p>
-      <b-button v-if="!isConnected" variant="primary" :to="{ name: $consts.urls.URL_AD_ALERT_LIST }"
+      <b-button v-if="isConnected" variant="primary" :to="{ name: $consts.urls.URL_AD_ALERT_LIST }"
         >{{ $t("btn.manage-my-alerts") }}
       </b-button>
       <b-button v-else variant="primary" :to="{ name: $consts.urls.URL_LIST_AD }">{{ $t("btn.return-map") }} </b-button>
@@ -21,7 +21,6 @@ export default {
   },
   async mounted() {
     await deleteAlert(this.$route.params.id, this.$route.query.email);
-    this.$emit("deleted");
   },
   apollo: {
     user: {

--- a/YellowDuck.FE/src/components/pages/alert/delete.vue
+++ b/YellowDuck.FE/src/components/pages/alert/delete.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="alert-list w-100 mt-4 mt-md-5">
+    <div class="no-content my-5 py-sm-4">
+      <img class="no-content__img mb-4" alt="" :src="require('@/assets/ambiance/nothing.svg')" />
+      <p>{{ $t("notification.alert-deleted") }}</p>
+      <b-button v-if="!isConnected" variant="primary" :to="{ name: $consts.urls.URL_AD_ALERT_LIST }"
+        >{{ $t("btn.manage-my-alerts") }}
+      </b-button>
+      <b-button v-else variant="primary" :to="{ name: $consts.urls.URL_LIST_AD }">{{ $t("btn.return-map") }} </b-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { deleteAlert } from "@/services/alert";
+export default {
+  computed: {
+    isConnected() {
+      return this.user && this.user.isConnected;
+    }
+  },
+  async mounted() {
+    await deleteAlert(this.$route.params.id, this.$route.query.email);
+    this.$emit("deleted");
+  },
+  apollo: {
+    user: {
+      query() {
+        return this.$options.query.LocalUser;
+      }
+    }
+  }
+};
+</script>
+<graphql>
+query LocalUser {
+  user @client {
+    isConnected
+  }
+}
+</graphql>

--- a/YellowDuck.FE/src/components/pages/alert/list.vue
+++ b/YellowDuck.FE/src/components/pages/alert/list.vue
@@ -9,6 +9,7 @@
           v-for="alert in alerts"
           :key="alert.id"
           :alert="alert"
+          :email="me.email"
           @deleted="refreshAlerts()"
           sectionWidth="sm"
           smallTitle
@@ -29,10 +30,8 @@
 <script>
 import AlertNoContent from "@/components/alert/no-content.vue";
 import AlertSnippet from "@/components/alert/snippet.vue";
-import { RatingsCriterias } from "@/mixins/ratings-criterias";
 
 export default {
-  mixins: [RatingsCriterias],
   components: {
     AlertNoContent,
     AlertSnippet
@@ -78,6 +77,7 @@ export default {
 query Me {
   me {
     id
+    email
     profile {
       id
     }

--- a/YellowDuck.FE/src/consts/urls.js
+++ b/YellowDuck.FE/src/consts/urls.js
@@ -14,6 +14,7 @@ export const URL_AD_DETAIL = "detail-ad-url";
 export const URL_AD_ALERT_LIST = "list-alert-ad-url";
 export const URL_AD_ALERT_ADD = "add-alert-ad-url";
 export const URL_AD_ALERT_EDIT = "edit-alert-ad-url";
+export const URL_AD_ALERT_DELETE = "delete-alert-ad-url";
 export const URL_CREATE_CONVERSATION = "create-conversation-url";
 export const URL_RESEND_CONFIRMATION_EMAIL = "resend-confirmation-email-url";
 export const URL_AD_EDIT = "edit-ad-url";

--- a/YellowDuck.FE/src/locales/en.json
+++ b/YellowDuck.FE/src/locales/en.json
@@ -560,5 +560,7 @@
   "label.send-to": "And who do we send this to?",
   "label.your-email": "Your email",
   "form-complete.create-alert.title": "Alert created",
-  "form-complete.create-alert.description": "Your alert has now been set. From now on, you will receive new offers that meet your criteria once a week."
+  "form-complete.create-alert.description": "Your alert has now been set. From now on, you will receive new offers that meet your criteria once a week.",
+  "notification.alert-deleted": "The alert has been deleted.",
+  "notification.alert-confirmed": "The alert has been confirmed. From now on, you will receive new offers that meet your criteria once a week."
 }

--- a/YellowDuck.FE/src/locales/fr.json
+++ b/YellowDuck.FE/src/locales/fr.json
@@ -571,5 +571,6 @@
   "profile-detail.no-alerts": "Vous n'avez aucune alerte.",
   "form-complete.edit-alert.title": "Alerte modifiée",
   "form-complete.edit-alert.description": "Votre alerte a bien été modifié. Vous receverez donc à partir de maintenant les nouvelles offres qui répondent à vos critères une fois par semaine.",
-  "notification.alert-deleted": "L'alerte à bien été supprimée."
+  "notification.alert-deleted": "L'alerte à bien été supprimée.",
+  "notification.alert-confirmed": "L'alerte à bien été confirmée. Vous receverez donc à partir de maintenant les nouvelles offres qui répondent à vos critères une fois par semaine."
 }

--- a/YellowDuck.FE/src/routes.js
+++ b/YellowDuck.FE/src/routes.js
@@ -233,6 +233,14 @@ export default [
     }
   },
   {
+    name: urls.URL_AD_ALERT_CONFIRM,
+    path: "/alertes/confirmer/:id",
+    component: () => import("@/components/pages/alert/confirm.vue"),
+    meta: {
+      anonymous
+    }
+  },
+  {
     name: urls.URL_AD_ALERT_EDIT,
     path: "/alertes/modifier/:id",
     component: () => import("@/components/pages/alert/edit.vue"),

--- a/YellowDuck.FE/src/routes.js
+++ b/YellowDuck.FE/src/routes.js
@@ -240,6 +240,14 @@ export default [
       usertype: USER_TYPE_USER
     }
   },
+  {
+    name: urls.URL_AD_ALERT_DELETE,
+    path: "/alertes/supprimer/:id",
+    component: () => import("@/components/pages/alert/delete.vue"),
+    meta: {
+      anonymous
+    }
+  },
 
   {
     name: urls.URL_LIST_CONVERSATION,

--- a/YellowDuck.FE/src/services/alert.graphql
+++ b/YellowDuck.FE/src/services/alert.graphql
@@ -19,3 +19,11 @@ mutation DeleteAlert($input: DeleteAlertInput!) {
     success
   }
 }
+
+mutation ConfirmAlert($input: ConfirmAlertInput!) {
+  confirmAlert(input: $input) {
+    alert {
+      id
+    }
+  }
+}

--- a/YellowDuck.FE/src/services/alert.js
+++ b/YellowDuck.FE/src/services/alert.js
@@ -1,5 +1,5 @@
 import Apollo from "@/graphql/vue-apollo";
-import { CreateAlert, UpdateAlert, DeleteAlert } from "./alert.graphql";
+import { CreateAlert, UpdateAlert, DeleteAlert, ConfirmAlert } from "./alert.graphql";
 import { addMaybeValue } from "@/helpers/graphql";
 
 import { getAddressFromGooglePlace } from "@/services/google-map";
@@ -71,6 +71,22 @@ export async function deleteAlert(alertId, email) {
 
   let result = await Apollo.instance.defaultClient.mutate({
     mutation: DeleteAlert,
+    variables: {
+      input: mutationInput
+    }
+  });
+
+  return result;
+}
+
+export async function confirmAlert(alertId, email) {
+  let mutationInput = {
+    alertId,
+    email
+  };
+
+  let result = await Apollo.instance.defaultClient.mutate({
+    mutation: ConfirmAlert,
     variables: {
       input: mutationInput
     }

--- a/YellowDuck.FE/src/services/alert.js
+++ b/YellowDuck.FE/src/services/alert.js
@@ -63,9 +63,10 @@ export async function updateAlert(input) {
 }
 
 
-export async function deleteAlert(alertId) {
+export async function deleteAlert(alertId, email) {
   let mutationInput = {
-    alertId
+    alertId,
+    email
   };
 
   let result = await Apollo.instance.defaultClient.mutate({


### PR DESCRIPTION
Les dernières fonctionnalités des alertes:

- Job Hangfire une fois par jour qui regarde les alertes qui n'ont pas été envoyé dans les 7 derniers jours et filtre les annonces publiées depuis le même laps de temps  sur les critères de l'alerte. S'il y a une ou des annonces, un courriel est envoyé.
- Fonctionnalité de désabonnement (sans login) pour avoir un lien unsubscribe dans le email.
- Double opt-in de l'alerte lorsque celle-ci n'est pas lié à un compte.
- Lors de la création d'un compte, si des alertes sont déjà lié à l'adresse courriel, les liés au compte.