### PR TITLE
Ajout checkbox pour confirmer la véracité de l'annonce

### DIFF
--- a/YellowDuck.FE/src/components/ad/form.vue
+++ b/YellowDuck.FE/src/components/ad/form.vue
@@ -190,7 +190,7 @@
       </fieldset>
     </div>
 
-    <div class="section section--md mt-4 mb-5">
+    <div class="section section--md section--padding-x section--border-bottom my-4 pb-5 rm-child-margin">
       <h2 class="my-4">{{ $t("section-title.contact-details") }}</h2>
       <s-form-input
         v-model="form.organization"
@@ -211,6 +211,16 @@
         required
       />
       <s-form-checkbox v-model="form.showAddress" id="showAddress" :label="$t('label.ad-showAddress')" name="showAddress" />
+    </div>
+    <div class="section section--md mt-4 mb-5">
+      <s-form-checkbox
+        v-model="form.infoIsTrue"
+        id="infoIsTrue"
+        :label="$t('label.infoIsTrue')"
+        name="infoIsTrue"
+        :rules="{ required: { allowFalse: false } }"
+        required
+      />
     </div>
     <div class="fab-container__fab">
       <div class="section section--md">
@@ -392,6 +402,10 @@ export default {
       type: String,
       default: ""
     },
+    infoIsTrue: {
+      type: Boolean,
+      default: false
+    },
     btnLabel: {
       type: String,
       required: true
@@ -448,12 +462,14 @@ export default {
         eveningAvailability: this.eveningAvailability || [],
         refrigerated: this.refrigerated,
         canSharedRoad: this.canSharedRoad,
-        canHaveDriver: this.canHaveDriver
+        canHaveDriver: this.canHaveDriver,
+        infoIsTrue: this.infoIsTrue
       },
       CATEGORY_PROFESSIONAL_KITCHEN,
       CATEGORY_DELIVERY_TRUCK,
       CATEGORY_STORAGE_SPACE,
       CATEGORY_OTHER
+
     };
   },
   components: {
@@ -577,10 +593,12 @@ export default {
         "eveningAvailability",
         "refrigerated",
         "canSharedRoad",
-        "canHaveDriver"
+        "canHaveDriver",
+        "infoIsTrue"
       ];
       for (let maybeEditedField of maybeEditedFields) {
         if (
+
           Array.isArray(this[maybeEditedField]) &&
           this[maybeEditedField].sort().join(",") === this.form[maybeEditedField].sort().join(",")
         ) {

--- a/YellowDuck.FE/src/locales/en.json
+++ b/YellowDuck.FE/src/locales/en.json
@@ -611,8 +611,8 @@
   "accept-tos.button": "I Accept",
   "accept-tos.logout": "Not now, log me out",
   "text.landing-page-terms-feed": "Cookies preferences",
-  "label.isAvailableForRent": "",
-  "label.ad-rent-price": "",
+  "label.isAvailableForRent": "Is available for rent",
+  "label.ad-rent-price": "Rent price",
   "placeholder.ad-rent-price": "100",
   "label.isAvailableForSale": "Is available for sale",
   "label.ad-sale-price": "Sale price",
@@ -632,5 +632,6 @@
   "label.drop-files": "Drop files here",
   "notification.conversation-no-dangerous-files": "Some selected files are not allowed. They have been ignored.",
   "notification.conversation-file-size-limit": "The maximum size of a message is 100 MB. File(s) exceeding this size have been ignored.",
-  "use-of-masculine-notice": ""
+  "use-of-masculine-notice": "",
+  "label.infoIsTrue": "I declare that the information provided in the ad is true."
 }

--- a/YellowDuck.FE/src/locales/fr.json
+++ b/YellowDuck.FE/src/locales/fr.json
@@ -630,5 +630,6 @@
   "label.drop-files": "Déposez vos fichiers ici",
   "notification.conversation-no-dangerous-files": "Certain(s) fichier(s) sélectionné(s) ne sont pas autorisé(s). Il(s) ont été ignoré(s).",
   "notification.conversation-file-size-limit": "La taille maximale d'un message est de 100 Mo. Le(s) fichier(s) excédant cette taille ont été ignoré(s).",
-  "use-of-masculine-notice": "L'utilisation du genre masculin a été adoptée afin de faciliter la lecture et n'a aucune intention discriminatoire."
+  "use-of-masculine-notice": "L'utilisation du genre masculin a été adoptée afin de faciliter la lecture et n'a aucune intention discriminatoire.",
+  "label.infoIsTrue": "J’affirme que les informations déclarées dans l’annonce sont véridiques."
 }


### PR DESCRIPTION
Tâche ici https://sigmund-ca.atlassian.net/browse/MUT-436

Avec Christopher, on s'était entendu pour dire qu'on n'avait pas besoin d'enregistrer l'info dans le BE parce que toutes les annonces après la date de release de cette feature devraient techniquement être confirmées pour pourvoir être ajoutées. Par contre, je ne sais pas si le comportement est correct quand on vient pour modifier une annonce. Ce champ retourne à la valeur "false", donc il faut le réappliquer pour enregistrer les modifs. Est-ce que ça a du sens selon toi ?

Voici ce que ça donne visuellement:
![screenshot-localhost_62543-2025_02_07-16_11_41](https://github.com/user-attachments/assets/dbb8e857-a92d-47e0-ac55-ad2a92ef0a53)
