### PR TITLE
Fix issue with phone number flagged as confirm when in reality it was not yet

### DIFF
--- a/YellowDuck.Api/Controllers/PhoneController.cs
+++ b/YellowDuck.Api/Controllers/PhoneController.cs
@@ -110,6 +110,7 @@ namespace YellowDuck.Api.Controllers
             if (user != null)
             {
                 var isLocalhost = Request.Host.Host.Contains("localhost");
+                user.PhoneNumberConfirmed = true;
                 await _phoneVerificationService.SetBypass2FATokenForUser(user, Response, isLocalhost);
             }
 

--- a/YellowDuck.FE/src/components/user-profile/edit.vue
+++ b/YellowDuck.FE/src/components/user-profile/edit.vue
@@ -312,7 +312,7 @@ export default {
         const cleanNewNumber = newPhoneNumber ? newPhoneNumber.replace(/\D/g, "") : "";
         const cleanProfileNumber = this.userProfile.phoneNumber ? this.userProfile.phoneNumber.replace(/\D/g, "") : "";
 
-        this.phoneNumberIsConfirmed = cleanNewNumber === cleanProfileNumber;
+        this.phoneNumberIsConfirmed = cleanNewNumber === cleanProfileNumber && this.userProfile.user.phoneNumberConfirmed;
       }
     }
   }


### PR DESCRIPTION
Le code prenait l'assomption que le numéro de téléphone était valide, puisque dans la création d'un compte, on force à valider le numéro de téléphone, mais il existe des cas d'ancien compte qui n'ont toujours pas valider leur numéro de téléphone.