### PR TITLE
Permettre de joindre un fichier seulement sur une conversation déjà créée

### DIFF
--- a/YellowDuck.FE/src/components/conversation/form.vue
+++ b/YellowDuck.FE/src/components/conversation/form.vue
@@ -31,12 +31,13 @@
       >
         <template #input-group-append>
           <b-input-group-append>
-            <b-button type="submit" variant="warning" :aria-label="$t('sr.send-message')">
+            <b-button type="submit" variant="warning">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-send-fill" viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M15.964.686a.5.5 0 0 0-.65-.65L.767 5.855H.766l-.452.18a.5.5 0 0 0-.082.887l.41.26.001.002 4.995 3.178 3.178 4.995.002.002.26.41a.5.5 0 0 0 .886-.083zm-1.833 1.89L6.637 10.07l-.215-.338a.5.5 0 0 0-.154-.154l-.338-.215 7.494-7.494 1.178-.471z"/>
               </svg>
+              <span :class="conversationSid ? 'sr-only' : 'ml-2'">{{ conversationSid ? $t("sr.send-message") : $t("sr.send-first-message") }}</span>
             </b-button>
-            <b-button type="button" variant="outline-primary" @click="triggerFileUpload">
+            <b-button v-if="conversationSid" type="button" variant="outline-primary" @click="triggerFileUpload">
               <b-icon icon="paperclip" aria-hidden="true"></b-icon>
               <span class="attach-file-label sr-only">{{ $t("sr.upload-files") }}</span>
             </b-button>

--- a/YellowDuck.FE/src/locales/en.json
+++ b/YellowDuck.FE/src/locales/en.json
@@ -586,6 +586,7 @@
   "sr.play-video": "Play video",
   "sr.edit": "Edit",
   "sr.send-message": "Send message",
+  "sr.send-first-message": "Start the conversation",
   "sr.open": "Open",
   "sr.close": "Close",
   "sr.user-menu-toggle": "user menu",

--- a/YellowDuck.FE/src/locales/fr.json
+++ b/YellowDuck.FE/src/locales/fr.json
@@ -585,6 +585,7 @@
   "sr.play-video": "Jouer la vidéo",
   "sr.edit": "Éditer",
   "sr.send-message": "Envoyer le message",
+  "sr.send-first-message": "Débuter la conversation",
   "sr.open": "Ouvrir",
   "sr.close": "Fermer",
   "sr.user-menu-toggle": "le menu utilisateur",


### PR DESCRIPTION
L'upload de fichier ne fonctionnait pas si la conversation n'existe pas encore.